### PR TITLE
Move breadcrums and toc to utils.html

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+{% from "utils.html" import make_breadcrums, make_toc %}
 
 {% block body %}
 
@@ -35,18 +36,7 @@
     {% endblock %}
 
     {% block sidebar %}
-    {% if this.toc %}
-    <div class="col-md-3" role="complementary">
-      <nav class="hidden-print hidden-xs hidden-sm">
-        <div class="sidebar" data-spy="affix" data-offset-top="80" data-offset-bottom="60">
-          <div class="well">
-            <a href="#"><strong>{{this.title}}</strong></a>
-            {{this.toc}}
-          </div>
-        </div>
-      </nav>
-    </div>
-    {% endif %}
+        {{ make_toc(this) }}
     {% endblock %}
 
   </div>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -5,15 +5,7 @@
 <div class="container">
 
   {% block breadcrumbs %}
-  {% if this.breadcrumbs %}
-  <ol class="breadcrumb">
-    <li><a href="{{url_prefix + '/'}}">Home</a></li>
-      {% for bc in this.breadcrumbs[:-1] %}
-      <li><a href="{{bc.url}}">{{bc.title}}</a></li>
-      {% endfor %}
-      <li class="active">{{this.breadcrumbs[-1].title}}</li>
-  </ol>
-  {% endif %}
+      {{ make_breadcrums(this) }}
   {% endblock %}
 
   <div class="page-header">

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -1,19 +1,12 @@
 {% extends "_base.html" %}
+{% from "utils.html" import make_breadcrums %}
 
 {% block body %}
 
 <div class="container">
 
   {% block breadcrumbs %}
-  {% if this.breadcrumbs %}
-  <ol class="breadcrumb">
-    <li><a href="{{url_prefix + '/'}}">Home</a></li>
-      {% for bc in this.breadcrumbs[:-1] %}
-      <li><a href="{{bc.url}}">{{bc.title}}</a></li>
-      {% endfor %}
-      <li class="active">{{this.breadcrumbs[-1].title}}</li>
-  </ol>
-  {% endif %}
+      {{ make_breadcrums(this) }}
   {% endblock %}
 
   <div class="page-header">

--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -1,5 +1,5 @@
 {% extends "_base.html" %}
-{% from "utils.html" import make_breadcrums %}
+{% from "utils.html" import make_breadcrums, make_toc %}
 
 {% block body %}
 
@@ -36,18 +36,7 @@
     {% endblock %}
 
     {% block sidebar %}
-    {% if this.toc %}
-    <div class="col-md-3" role="complementary">
-      <nav class="hidden-print hidden-xs hidden-sm">
-        <div class="sidebar" data-spy="affix" data-offset-top="80" data-offset-bottom="60">
-          <div class="well">
-            <a href="#"><strong>{{this.title}}</strong></a>
-            {{this.toc}}
-          </div>
-        </div>
-      </nav>
-    </div>
-    {% endif %}
+        {{ make_toc(this) }}
     {% endblock %}
 
   </div>

--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -110,3 +110,16 @@
 		</a>
 	{%- endif -%}
 {%- endmacro -%}
+
+
+{%- macro make_breadcrums(page) -%}
+    {% if page.breadcrumbs %}
+        <ol class="breadcrumb">
+            <li><a href="/">Home</a></li>
+            {% for bc in page.breadcrumbs[:-1] %}
+                <li><a href="{{bc.url}}">{{bc.title}}</a></li>
+            {% endfor %}
+            <li class="active">{{page.breadcrumbs[-1].title}}</li>
+        </ol>
+    {% endif %}
+{%- endmacro -%}

--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -123,3 +123,19 @@
         </ol>
     {% endif %}
 {%- endmacro -%}
+
+
+{%- macro make_toc(page) -%}
+    {% if page.toc %}
+        <div class="col-md-3" role="complementary">
+            <nav class="hidden-print hidden-xs hidden-sm">
+                <div class="sidebar" data-spy="affix" data-offset-top="80" data-offset-bottom="60">
+                    <div class="well">
+                        <a href="#"><strong>{{page.title}}</strong></a>
+                        {{page.toc}}
+                    </div>
+                </div>
+            </nav>
+        </div>
+    {% endif %}
+{%- endmacro -%}


### PR DESCRIPTION
Create functions to create breadcrums and toc macros.
Because they surely be applied to several layouts, it's better to have a macro instead of copy pasting code.