### PR TITLE
Remove "content" from poster and publications

### DIFF
--- a/posters/index.md
+++ b/posters/index.md
@@ -1,9 +1,7 @@
 ---
 title: Posters
 layout: index
-
-content:
-    - lapis2019
+order: date
 
 banner:
     title: Posters

--- a/publications/index.md
+++ b/publications/index.md
@@ -1,10 +1,7 @@
 ---
 title: Publications
 layout: index
-
-content:
-    - soler2018
-    - gianni2018
+order: date
 
 banner:
     title: Publications


### PR DESCRIPTION
Instead of explicit the content, the indexes sort them by date.

Fix #80