### PR TITLE
Pin markdown version to lower than 3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     # Install Urubu's requirements from conda
     - jinja2>=2.7
     - beautifulsoup4
-    - markdown=2.6.11
+    - markdown<3
     - pygments
     - pyyaml
     - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
     # Install Urubu's requirements from conda
     - jinja2>=2.7
     - beautifulsoup4
-    - markdown
+    - markdown=2.6.11
     - pygments
     - pyyaml
     - pip:


### PR DESCRIPTION
Newer version of `markdown` (`> 3`) are not compatible with latest release of `urubu`.


Fixes #100