### PR TITLE
Remove Contact link from navbar

### DIFF
--- a/_site.yml
+++ b/_site.yml
@@ -108,7 +108,6 @@ navbar_items: [
     ["Projects", "/projects"],
     ["Publications", "/publications"],
     ["Posters", "/posters"],
-    ["Contact", "/about.html#contact"],
     ]
 
 navbar_icons: [

--- a/about.md
+++ b/about.md
@@ -64,7 +64,8 @@ I consider myself an amateur photographer as well.
 - Thesis: [Métodos Espectrales para la Determinación de la Profundidad del Punto de Curie y el Espesor Elástico de la Corteza Terrestre](https://github.com/santisoler/tesina-fisica)
 
 
-# Contact
+# Contact and Profiles
 
 - {{ draw_icon("mail", site) }} [santiago.r.soler@gmail.com](mailto:santiago.r.soler@gmail.com)
 - {{ draw_icon("github", site) }} [santisoler](https://www.github.com/santisoler)
+- {{ draw_icon("orcid", site) }} ORCID: [0000-0001-9202-5317](https://orcid.org/0000-0001-9202-5317)


### PR DESCRIPTION
The navbar icons are a quicker way to show how to contact me or find me online.
Also add ORCID to About/Contact.

Fixes #98 