### PR TITLE
Make authors name linkable to their personal websites

### DIFF
--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -58,7 +58,7 @@
     <div class="col-md-10">
         <a href={{ article.url }}><h2 class="item">{{ article.title }}</h2></a>
         <p class="item">
-            {{ get_authors(article, site) }} ({{ article.date.year }})
+            {{ get_authors(article, site, add_url=false) }} ({{ article.date.year }})
         </p>
         <p class="item">
             <em>{{ article.journal }}.</em>
@@ -82,7 +82,7 @@
     <div class="col-md-10">
         <a href={{ poster.url }}><h2 class="item">{{ poster.title }}</h2></a>
         <p class="item">
-            {{ get_authors(poster, site) }} ({{ poster.date.year }})
+            {{ get_authors(poster, site, add_url=false) }} ({{ poster.date.year }})
         </p>
         <p class="item">
             Presented at
@@ -127,15 +127,22 @@
 
 {# Other functions #}
 
-{%- macro get_authors(article, site, fancy=true) -%}
+{%- macro get_authors(article, site, fancy=true, add_url=true) -%}
     {# Make the author list by expanding the stubs into full names from "site.authors" #}
     {%- for author in article.author.split(', ') -%}
+        {# Set author_name if fancy is true or false #}
         {%- if fancy and author == "me" -%}
-            {% set author_name = "<strong>" + site.authors[author] + "</strong>" -%}
+            {% set author_name = "<strong>" + site.authors[author].name + "</strong>" -%}
         {%- else -%}
-            {% set author_name = site.authors[author] -%}
+            {% set author_name = site.authors[author].name -%}
         {%- endif -%}
-        {{ author_name }}
+        {# Print author name if they have an url #}
+        {%- if add_url and site.authors[author].url -%}
+            <a href={{ site.authors[author].url }}>{{ author_name }}</a>
+        {%- else -%}
+            {{ author_name }}
+        {%- endif -%}
+        {# Check if a comma or an "and" must be added or not after the author name #}
         {%- if not loop.last -%}
             {%- if loop.revindex == 2 -%}
                 {{ " and " }}

--- a/_site.yml
+++ b/_site.yml
@@ -102,11 +102,19 @@ icons:
 
 
 authors:
-    me: Santiago R. Soler
-    agustina: Agustina Pesce
-    guido: Guido M. Gianni
-    mario: Mario E. Giménez
-    leo: Leonardo Uieda
+    me:
+      name: Santiago R. Soler
+      url: https://santisoler.github.io/
+    agustina:
+      name: Agustina Pesce
+      url: https://github.com/aguspesce
+    guido:
+      name: Guido M. Gianni
+    mario:
+      name: Mario E. Giménez
+    leo:
+      name: Leonardo Uieda
+      url: https://www.leouieda.com/
 
 navbar_items: [
     ["About", "/about.html"],


### PR DESCRIPTION
Add ulr to author personal website on `_site.yml`. Improve how author names are shown.

A step forward #65.