### PR TITLE
Improve home item and information for posters

### DIFF
--- a/_layouts/poster.html
+++ b/_layouts/poster.html
@@ -15,11 +15,11 @@
 
         <h2>Information</h2>
         <ul>
-            <li>Presented at
+            <li>Presented at {{ " " }}
                 {%- if this.meeting_url is defined -%}
                     <a href="{{ this.meeting_url }}">
                 {%- endif -%}
-                {{ " " + this.meeting }}
+                {{ this.meeting }}
                 {%- if this.meeting_url is defined -%}
                     </a>
                 {%- endif -%}

--- a/_layouts/utils.html
+++ b/_layouts/utils.html
@@ -85,16 +85,17 @@
             {{ get_authors(poster, site, add_url=false) }} ({{ poster.date.year }})
         </p>
         <p class="item">
-            Presented at
+        Presented at {{ " " }}
             {%- if poster.meeting_url is defined -%}
                 <a href="{{ poster.meeting_url }}">
             {%- endif -%}
-            {{ " " + poster.meeting }}.
+            {{ poster.meeting }}.
             {%- if poster.meeting_url is defined -%}
                 </a>
             {%- endif -%}
             {%- if poster.doi is defined -%}
-                {{ " doi: " }}
+                <br>
+                {{ "doi: " }}
                 <a href="https://www.doi.org/{{ poster.doi }}">{{ poster.doi }}</a>.
             {%- endif -%}
         </p>


### PR DESCRIPTION
Improve format of link to meeting and add a line break before the doi in
the poster home item.