### PR TITLE
Remove publish target on Makefile and add clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,5 @@ build:
 serve:
 	python -m urubu serve
 
-publish:
-	git subtree push --prefix _build origin gh-pages
-
 clean:
 	rm -rf _build

--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,7 @@ serve:
 	python -m urubu serve
 
 publish:
-	git subtree push --prefix _build origin gh-pages    
+	git subtree push --prefix _build origin gh-pages
+
+clean:
+	rm -rf _build


### PR DESCRIPTION
Add clean target to Makefile to delete the created _build directory. The publish target
on the Makefile was old and is not intended to be used, it was removed safety.