### PR TITLE
Use hashes for GitHub Actions instead of tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,8 @@ jobs:
 
     - name: Deploy to santisoler.github.io
       if: success() && github.event_name == 'push'
-      uses: peaceiris/actions-gh-pages@v3
+      # Don't use tags: https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
+      uses: peaceiris/actions-gh-pages@8a36f3edfc5d1cbae6b09e6f5a7d7b19e5b7a73b
       with:
         deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
         external_repository: santisoler/santisoler.github.io


### PR DESCRIPTION
Use the commit hash for referring a certain version of a third-party GitHub Action
instead of it's tag for security issues. The problem is explained here:
https://julienrenaux.fr/2019/12/20/github-actions-security-risk/